### PR TITLE
browser-specific native host names with fallback to preivous host 

### DIFF
--- a/WebExtension/background.js
+++ b/WebExtension/background.js
@@ -22,10 +22,8 @@
 
 const DEBUG = true;
 const VERSION = "4.0.0"; // TODO: Does it work?
-// const hostName = getNativeHostName();
 const browserEnv = getBrowserApi();
 const BrowserNameSpace = browserEnv.BrowserNameSpace;
-
 
 // Only set up config (icons, context menu) on install/startup, not native connection
 async function ensureExtensionConfigOnStartup() {
@@ -46,9 +44,7 @@ function detectBrowser() {
     const ua = navigator.userAgent;
     if (ua.includes("Edg")) return "edge";
     if (navigator.brave && typeof navigator.brave.isBrave === "function") return "brave";
-    if (ua.includes("Vivaldi")) return "vivaldi";
     if (ua.includes("OPR")) return "opera";
-    if (ua.includes("Chromium")) return "chromium";
     if (ua.includes("Firefox")) return "firefox";
     if (ua.includes("Chrome")) return "chrome";
     return "unknown";
@@ -122,7 +118,7 @@ async function detectLibreWolf() {
 async function initializeNativeConnection() {
     console.log("[PDM] initializeNativeConnection called");
 
-    // Detect browser and build candidate hosts
+    // Detect browser type and set hosts accordingly
     let browser = detectBrowser();
     let hosts = [];
     // Special handling for LibreWolf (async detection)
@@ -133,6 +129,7 @@ async function initializeNativeConnection() {
 
     if (browser === 'chrome') {
         hosts = [
+            // For Chrome, Chromium, Vivaldi(Will be handled by Fallback Logic as their Identitiy is same,just detecting chromium based browsers is enough)
             'com.persepolis.chrome',
             'com.persepolis.vivaldi',
             'com.persepolis.chromium',
@@ -162,7 +159,6 @@ async function initializeNativeConnection() {
 
     throw new Error("Failed to initialize native connection: No available native host.");
 }
-
 
 
 

--- a/WebExtension/manifest.json
+++ b/WebExtension/manifest.json
@@ -43,8 +43,7 @@
     "downloads",
     "cookies",
     "storage",
-    "scripting",
-    "tabs"
+    "scripting"
   ],
   "host_permissions": ["*://*/"],
   "version": "4.0.0"

--- a/WebExtension/manifest.json
+++ b/WebExtension/manifest.json
@@ -1,16 +1,10 @@
 {
   "background": {
-    "service_worker": "background.js",
-    "scripts": [
-      "background.js"
-    ]
+    "service_worker": "background.js"
   },
   "action": {
-    "default_title": "PDM Integration",
-    "default_popup": "popup/popup.html",
-    "default_icon": {
-      "32": "icons/icon_32.png"
-    }
+    "default_icon": "icons/icon_32.png",
+    "default_popup": "popup/popup.html"
   },
   "content_scripts": [
     {
@@ -31,10 +25,7 @@
       "match_about_blank":true
     }
   ],
-
-  "key":"MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoCgWSDIitikIuLvTLERSUeSSRobagH6W9yZNsC+1+3XVX8Ae83ZPGbjuHhb4J2vQzSDfr2TiWeLya2z54JH2KCVTHdr++Mf8xlykobf83/HTu2LcQzI7RPb53KWgGMrEszuRQdxhSeYwogCR6BDQaRqRmBbsAg40VuLI53KtXrvESu3gNtDdIpG/S1EIxK6VnwXL+UXxVmPQxQ0tFyTX5R0tyBdbKAx7UwT9z8fQN4PP4QBHFzU4Pqrln66evdYb5NpZw9RAZxhLW4chk4kK2BMz4Ym10J1yOjvZ4w9MBHJsIn38EJSfYSDWOlUReZNoQXHN4J6UhMQbuWEZO6SbVwIDAQAB",
-
-  "description": "Persepolis Download Manager Integration extension replaces default download manager of FireFox by Persepolis Download Manager.",
+  "description": "Persepolis Download Manager Integration extension replaces default download manager of Google Chrome by Persepolis Download Manager.",
   "homepage_url": "https://github.com/persepolisdm/Persepolis-WebExtension",
   "icons": {
     "32": "icons/icon_32.png",
@@ -42,25 +33,19 @@
     "128": "icons/icon_128.png"
   },
   "manifest_version": 3,
-
+  "minimum_chrome_version": "19.0",
   "name": "Persepolis Download Manager Integration",
   "short_name": "Persepolis",
+  "offline_enabled": true,
   "permissions": [
     "nativeMessaging",
     "contextMenus",
     "downloads",
     "cookies",
     "storage",
-    "scripting"  
+    "scripting",
+    "tabs"
   ],
-  "version": "4.0.0",
   "host_permissions": ["*://*/"],
-  "content_security_policy": {},
-
-  "browser_specific_settings": {
-    "gecko": {
-      "id": "com.persepolis.pdmchromewrapper@persepolisdm.github.io",
-      "strict_min_version": "50.0"
-    }
-  }
+  "version": "4.0.0"
 }

--- a/WebExtension/popup/js/popup.js
+++ b/WebExtension/popup/js/popup.js
@@ -37,7 +37,7 @@ function setExtensionConfig() {
     BrowserNameSpace.runtime.sendMessage({
         type: "setExtensionConfig",
         data: {
-            pdmInterrupt, contextMenu, keywords 
+            pdmInterrupt, contextMenu, keywords
         }
     })
 
@@ -47,7 +47,24 @@ function setExtensionConfig() {
 $(document).ready(function () {
 
     BrowserNameSpace.runtime.sendMessage({ type: "getExtensionConfig" }, (config) => {
-        let { pdmInterrupt, contextMenu, keywords } = config
+        // --- ADDED CHECKS FOR ROBUSTNESS ---
+        if (BrowserNameSpace.runtime.lastError) {
+            console.error("Error receiving config from background:", BrowserNameSpace.runtime.lastError.message);
+            // Optionally, you can disable UI elements or show an error message to the user here.
+            return;
+        }
+        if (!config) {
+            console.error("Received undefined config from background script. Initializing with default values.");
+            // Provide default values if config is undefined to prevent errors
+            config = {
+                pdmInterrupt: false, // Default value if config is not received
+                contextMenu: false,  // Default value
+                keywords: ''         // Default value
+            };
+        }
+        // --- END OF ADDED CHECKS ---
+
+        let { pdmInterrupt, contextMenu, keywords } = config;
 
         //Init variables from config
         keywordsDom = $('#keywords');
@@ -62,11 +79,8 @@ $(document).ready(function () {
 
         //Listen on changes and save them immediately
         dlInterruptCheckBox.on("change", setExtensionConfig);
-        // keywordsDom.on("change",saveSettings);
 
         keywordsDom.on("change paste keyup", setExtensionConfig);
         contextMenuCheckbox.on("change", setExtensionConfig);
     });
-
-
 });

--- a/firefox_manifest.json
+++ b/firefox_manifest.json
@@ -1,4 +1,5 @@
 {
+
   "background": {
     "scripts": [
       "background.js"
@@ -28,8 +29,6 @@
     }
   ],
 
-
-
   "description": "Persepolis Download Manager Integration extension replaces default download manager of FireFox by Persepolis Download Manager.",
   "homepage_url": "https://github.com/persepolisdm/Persepolis-WebExtension",
   "icons": {
@@ -42,13 +41,12 @@
   "name": "Persepolis Download Manager Integration",
   "short_name": "Persepolis",
   "permissions": [
-    "<all_urls>",
-    "nativeMessaging",
-    "contextMenus",
     "downloads",
-    "cookies",
     "storage",
-    "scripting"
+    "cookies",
+    "contextMenus",
+    "scripting",
+    "nativeMessaging"
   ],
   "version": "4.0.0",
   "host_permissions": ["*://*/"],

--- a/librewolf_manifest.json
+++ b/librewolf_manifest.json
@@ -1,0 +1,53 @@
+{
+  "manifest_version": 2,
+  "name": "Persepolis Download Manager Integration",
+  "short_name": "Persepolis",
+  "version": "4.0.0",
+  "description": "Integrates Firefox/LibreWolf with Persepolis Download Manager.",
+  "homepage_url": "https://github.com/persepolisdm/Persepolis-WebExtension",
+
+  "background": {
+    "scripts": ["background.js"]
+  },
+
+  "browser_action": {
+    "default_icon": "icons/icon_32.png",
+    "default_popup": "popup/popup.html"
+  },
+
+  "content_scripts": [
+    {
+      "all_frames": true,
+      "js": ["contentScripts/content.js"],
+      "css": ["contentScripts/modal.css"],
+      "matches": ["<all_urls>"],
+      "run_at": "document_start",
+      "match_about_blank": true
+    }
+  ],
+
+  "permissions": [
+    "downloads",
+    "downloads.open",
+    "cookies",
+    "contextMenus",
+    "storage",
+    "nativeMessaging",
+    "webRequest",
+    "webRequestBlocking",
+    "<all_urls>"
+  ],
+
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "com.persepolis.pdmchromewrapper@persepolisdm.github.io",
+      "strict_min_version": "50.0"
+    }
+  },
+
+  "icons": {
+    "32": "icons/icon_32.png",
+    "48": "icons/icon_48.png",
+    "128": "icons/icon_128.png"
+  }
+}


### PR DESCRIPTION
implement reliable, browser-specific native host for New Browser Integration tab with fallback logic to previous Host 

When the extension detects browser it attempts to connect to new native host, if it fails it will connect to fallback host and whichever host name connected will be saved in extension's local storage all this happens only once at startup
Uses handshake-based validation for each host in order, saving the first successful host to storage.
Only Chrome uses the extended fallback order to detect chrome,vivaldi,chromium; other browsers retain a simple fallback to their specific host and fallback host
This ensures the extension works seamlessly across Chrome and Chromium-based browsers and firefox based browsers and provides a robust fallback to the persepolis wrapper if all else fails.
and some more fixes and minor tweaks just go through the code and test it yourself and report me 
i tested with chrome,chromium,firefox,librewolf,brave,vivaldi,opera